### PR TITLE
Update flatpak runtime to Gnome 48

### DIFF
--- a/com.raggesilver.BlackBox.json
+++ b/com.raggesilver.BlackBox.json
@@ -1,7 +1,7 @@
 {
   "app-id": "com.raggesilver.BlackBox",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "46",
+  "runtime-version": "48",
   "sdk": "org.gnome.Sdk",
   "command": "blackbox",
   "finish-args": [
@@ -37,17 +37,6 @@
           "type": "archive",
           "url": "https://gitlab.gnome.org/GNOME/vte/-/archive/3c8f66be867aca6656e4109ce880b6ea7431b895/vte-3c8f66be867aca6656e4109ce880b6ea7431b895.tar.gz",
           "sha256": "320618260a29c99ab68d1e8674f6d4926bbf1e7e6541e8e04898fad85bb6e1b9"
-        }
-      ]
-    },
-    {
-      "name": "json-glib",
-      "buildsystem": "meson",
-      "sources": [
-        {
-          "type": "archive",
-          "url": "https://gitlab.gnome.org/GNOME/json-glib/-/archive/23ae2f59bea7405d95218e82edb7f3c4c7c80a87/json-glib-23ae2f59bea7405d95218e82edb7f3c4c7c80a87.tar.gz",
-          "sha256": "9fa88f1b8fc926bfd7c4115354a06f79b7b30fa367450a3e7a36932e3b7022ba"
         }
       ]
     },

--- a/com.raggesilver.BlackBox.json
+++ b/com.raggesilver.BlackBox.json
@@ -41,17 +41,6 @@
       ]
     },
     {
-      "name": "marble",
-      "buildsystem": "meson",
-      "sources": [
-        {
-          "type": "archive",
-          "url": "https://gitlab.gnome.org/raggesilver/marble/-/archive/f240b2ec7d5cdacb8fdcc553703420dc5101ffdb/marble-f240b2ec7d5cdacb8fdcc553703420dc5101ffdb.tar.gz",
-          "sha256": "46c1172a53cf974a73dc13a2142d022ec6a8dfa614133815df3aa5ede9af0cc1"
-        }
-      ]
-    },
-    {
       "name": "blackbox",
       "builddir": true,
       "buildsystem": "meson",

--- a/patch_gnome48.patch
+++ b/patch_gnome48.patch
@@ -1,0 +1,20 @@
+diff --git a/src/widgets/ColorSchemeThumbnail.vala b/src/widgets/ColorSchemeThumbnail.vala
+index ab9c444..5d9011f 100644
+--- a/src/widgets/ColorSchemeThumbnail.vala
++++ b/src/widgets/ColorSchemeThumbnail.vala
+@@ -27,13 +27,13 @@ public class Terminal.ColorSchemeThumbnailProvider {
+   public static void init_resource () {
+     if (svg_content == null) {
+       try {
+-        uint8[] data;
++        string data;
+ 
+         GLib.File.new_for_uri (
+           "resource:///com/raggesilver/BlackBox/resources/svg/color-scheme-thumbnail.svg"
+         ).load_contents (null, out data, null);
+ 
+-        svg_content = (string) data;
++        svg_content = data;
+       }
+       catch (Error e) {
+         error ("%s", e.message);


### PR DESCRIPTION
I'm trying to fix #12 , from this:

> Looks like json-glib was dropped from the [upstream Flatpak manifest](https://gitlab.gnome.org/raggesilver/blackbox/-/commit/313b1667ea1cdb6005f004f6b57f64fca0d65f82), probably because it is included in the GNOME runtime

I gather that it doesn't require to build `json-glib` anymore because is included on the Gnome runtime so the build should not fail anymore.